### PR TITLE
Trigger livereload on error

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -43,7 +43,9 @@ var plugin = {
       port: options.port,
       watcher: watcher
     });
-    return watcher.on('change', function(results) { watcher.emit('livereload'); });
+    return watcher
+      .on('change', function(results) { watcher.emit('livereload'); })
+      .on('error', function(results) { watcher.emit('livereload'); });
   },
   watch: function(dest, config) {
     var builder = this.builder(config);


### PR DESCRIPTION
I forgot to trigger livereload on errors to show error messages in browser. I fixed it now.
Also it would be nice if you could publish this package to the npm.
