### PR TITLE
Plugin now only replace the contents of the destination directory

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -5,6 +5,20 @@ var mkdirp = require('mkdirp');
 var path = require('path');
 var copyDereferenceSync = require('copy-dereference').sync;
 var Watcher = require('broccoli-sane-watcher');
+var fs = require("fs");
+
+// Write the results tree to the dest path without blowing away the entire dest
+// directory first. Remove all contents of dest, and place the contents of the
+// results tree into it.
+function write(src, dest){
+  mkdirp.sync(dest);
+  fs.readdirSync(dest).forEach(function(file) {
+    rimraf.sync(path.join(dest, file));
+  });
+  fs.readdirSync(src).forEach(function(file) {
+    copyDereferenceSync(path.join(src, file), path.join(dest, file));
+  });
+}
 
 var plugin = {
   builder: function(config) {
@@ -26,10 +40,7 @@ var plugin = {
     var builder = this.builder(config);
     return builder.build()
       .then(function(output) {
-        rimraf.sync(dest);
-        mkdirp.sync(path.join(dest, '..'));
-        copyDereferenceSync(output.directory, dest);
-
+        write(output.directory, dest);
         return builder.cleanup().then(function() {
           return output;
         });
@@ -51,9 +62,7 @@ var plugin = {
     var builder = this.builder(config);
     var watcher = new Watcher(builder, { interval: 100, verbose: true });
     return watcher.on('change', function(results) {
-      rimraf.sync(dest);
-      mkdirp.sync(path.join(dest, '..'));
-      copyDereferenceSync(results.directory, dest);
+      write(results.directory, dest);
       watcher.emit('livereload');
     });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-sane-broccoli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Broccoli build and serve tasks for Grunt task runner using the sane watcher",
   "main": "Gruntfile.js",
   "tags": [


### PR DESCRIPTION
Plugin now only replace the contents of the destination directory, instead of deleting the entire destination directory and re-creating it.

Processes started in the destination directory before grunt-broccoli fail when grunt-broccoli destroys their cwd.
