### PR TITLE
Actually output the stack trace when a build fails and Bump to 0.6.2

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -31,7 +31,7 @@ var plugin = {
       try {
         tree = require(configPath);
       } catch(e) {
-        // grunt.fatal("Unable to load Broccoli config file: " + e.message);
+        console.error(e.stack);
       }
     }
     return new broccoli.Builder(tree);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-sane-broccoli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Broccoli build and serve tasks for Grunt task runner using the sane watcher",
   "main": "Gruntfile.js",
   "tags": [


### PR DESCRIPTION
Before this no error output was actually printed if broccoli builds failed.
