### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a fork of [grunt-broccoli](https://github.com/quandl/grunt-broccoli), su
 
 ## Deprecated
 
-This module has been deprecated in favor of [grunt-broccoli ^1.0.0](https://github.com/EmberSherpa/grunt-broccoli/blob/master/CHANGELOG.md). That module now depends on Broccoli ^1.0.0, which has integrated the code from broccoli-sane-watcher into core.
+This module has been deprecated in favor of [grunt-broccoli ^1.0.0](https://github.com/EmberSherpa/grunt-broccoli). That module now depends on Broccoli ^1.0.0, which has integrated the code from broccoli-sane-watcher into core.
 
 ## Running your tasks
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Allows you to execute your Broccoli configurations as Grunt tasks. [Broccoli](ht
 
 This is a fork of [grunt-broccoli](https://github.com/quandl/grunt-broccoli), substituting the default broccoli watcher with `broccoli-sane-watcher`.
 
+## Deprecated
+
+This module has been deprecated in favor of [grunt-broccoli ^1.0.0](https://github.com/EmberSherpa/grunt-broccoli/blob/master/CHANGELOG.md). That module now depends on Broccoli ^1.0.0, which has integrated the code from broccoli-sane-watcher into core.
+
 ## Running your tasks
 
 grunt-sane-broccoli is a multi-task so you must specify a target when running the task.


### PR DESCRIPTION
Hey there,

I thought first about reaching out to you in an email, but I couldn't find one on your profile, so I went with a PR instead.

I recently joined the [grunt-broccoli](https://github.com/EmberSherpa/grunt-broccoli/blob/master/CHANGELOG.md) project, and just now pushed a version 1.0.0 of that module to npm. It depends on the latest version of Broccoli, cleans up the API a little and added a new feature. To me (who's been using Broccoli outside of ember-cli for several years), there seems to be some confusion around which grunt-broccoli module was the right one to use. There are multiple forks on npm, since grunt-broccoli itself hadn't been updated for some time.

grunt-sane-broccoli is actually the one I've been using for about 1,5 years, so thank you for providing a useful plugin! :+1:

Anyway, I think it would be great to consolidate our efforts in [EmberSherpa/grunt-broccoli](https://github.com/EmberSherpa/grunt-broccoli/blob/master/CHANGELOG.md), and work together to make that module the best it can be!

Best regards,
Fredrik